### PR TITLE
#25 [Fix] - Show the degree symbol wrap it with <> fragment

### DIFF
--- a/pages/countries/[slug].tsx
+++ b/pages/countries/[slug].tsx
@@ -143,7 +143,7 @@ const Country = ({
                                     Lat / Long:{" "}
                                 </span>
                                 {country.latlng
-                                    ? `${country.latlng[0]}&deg / ${country.latlng[1]}&deg`
+                                    ? <>{country.latlng[0]}&deg; / {country.latlng[1]}&deg;</>
                                     : "N/A"}
                             </p>
                             <p className="font-light mt-2">


### PR DESCRIPTION
### Bug Description
#25 

### Fix
Make use of the React fragment so we can combine the HTML with the data needed from `{...}`

### Screenshot
<img width="1402" alt="Screen Shot 2022-12-03 at 11 50 52 PM" src="https://user-images.githubusercontent.com/31334333/205449679-f35852f2-19b6-4e62-b440-3fc78841100f.png">
