### PR TITLE
#29 [Enhancement] - Update mobile/tablet view size to be bigger

### DIFF
--- a/components/Country.tsx
+++ b/components/Country.tsx
@@ -15,7 +15,7 @@ const Country = ({ country }: CountryProps) => {
                     <img
                         src={country.flags.png}
                         alt={country.name}
-                        className="rounded-t-md w-full h-[250px] laptop:h-[200px] object-cover"
+                        className="rounded-t-md w-full tablet:h-[250px] laptop:h-[200px] tablet:object-cover"
                     />
                 </picture>
             </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -26,7 +26,7 @@ type FooterProps = {
 // Render component.
 const Footer = (props: FooterProps) => {
     return (
-        <footer className="dark-mode-container w-full px-6 tablet:px-16 py-6 border-t-2 border-gray-100 tablet:flex align-top justify-between gap-2">
+        <footer className="dark-mode-container w-full px-6 laptop:px-16 py-6 border-t-2 border-gray-100 tablet:flex align-top justify-between gap-2">
             <div className="mb-4">
                 <h2 className="font-bold text-sm laptop:text-base">
                     Frontend Mentor Challenge

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -26,7 +26,7 @@ type FooterProps = {
 // Render component.
 const Footer = (props: FooterProps) => {
     return (
-        <footer className="dark-mode-container w-full px-16 py-6 border-t-2 border-gray-100 tablet:flex align-top justify-between gap-2">
+        <footer className="dark-mode-container w-full px-6 tablet:px-16 py-6 border-t-2 border-gray-100 tablet:flex align-top justify-between gap-2">
             <div className="mb-4">
                 <h2 className="font-bold text-sm laptop:text-base">
                     Frontend Mentor Challenge

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -26,7 +26,7 @@ type FooterProps = {
 // Render component.
 const Footer = (props: FooterProps) => {
     return (
-        <footer className="dark-mode-container w-full px-6 laptop:px-16 py-6 border-t-2 border-gray-100 tablet:flex align-top justify-between gap-2">
+        <footer className="dark-mode-container w-full px-6 laptop:px-12 py-6 border-t-2 border-gray-100 tablet:flex align-top justify-between gap-2">
             <div className="mb-4">
                 <h2 className="font-bold text-sm laptop:text-base">
                     Frontend Mentor Challenge

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,7 +11,7 @@ const Header = () => {
 
     // Render.
     return (
-        <header className="dark-mode-container flex flex-col items-start tablet:flex-row flex-wrap tablet:justify-between tablet:items-center border-b-2 border-gray-100 w-full min-h-[8vh] px-6 tablet:px-16 py-6">
+        <header className="dark-mode-container flex flex-col items-start tablet:flex-row flex-wrap tablet:justify-between tablet:items-center border-b-2 border-gray-100 w-full min-h-[8vh] px-6 laptop:px-16 py-6">
             <h1 className="text-lg py-2 tablet:text-xl desktop:text-2xl">
                 Where in the world?
             </h1>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,7 +11,7 @@ const Header = () => {
 
     // Render.
     return (
-        <header className="dark-mode-container flex flex-col items-start tablet:flex-row flex-wrap tablet:justify-between tablet:items-center border-b-2 border-gray-100 w-full min-h-[8vh] px-6 laptop:px-16 py-6">
+        <header className="dark-mode-container flex flex-col items-start tablet:flex-row flex-wrap tablet:justify-between tablet:items-center border-b-2 border-gray-100 w-full min-h-[8vh] px-6 laptop:px-12 py-6">
             <h1 className="text-lg py-2 tablet:text-xl desktop:text-2xl">
                 Where in the world?
             </h1>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,7 +11,7 @@ const Header = () => {
 
     // Render.
     return (
-        <header className="dark-mode-container flex flex-row flex-wrap justify-between items-center border-b-2 border-gray-100 w-full min-h-[8vh] px-16 py-6">
+        <header className="dark-mode-container flex flex-col items-start tablet:flex-row flex-wrap tablet:justify-between tablet:items-center border-b-2 border-gray-100 w-full min-h-[8vh] px-6 tablet:px-16 py-6">
             <h1 className="text-lg py-2 tablet:text-xl desktop:text-2xl">
                 Where in the world?
             </h1>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -10,7 +10,7 @@ const NotFound : NextPage = () => {
                 <title>Ooops! Page Not Found.</title>
                 <link rel="icon" href="/favicon.ico" />
             </Head>
-            <div className='page-container w-full px-6 laptop:px-16 py-4 min-h-[70vh] bg-lt-mode-bg flex flex-col justify-center'>
+            <div className='page-container w-full px-6 laptop:px-12 py-4 min-h-[70vh] bg-lt-mode-bg flex flex-col justify-center'>
                 <h1 className='text-2xl'>🦄 Ooops ... 404! Page Not Found.</h1>
                 <p className='text-lt-mode-text leading-10'>Click here to return to <Link href='/'><a className='return-link'>homepage</a></Link>.</p>
             </div>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -10,9 +10,9 @@ const NotFound : NextPage = () => {
                 <title>Ooops! Page Not Found.</title>
                 <link rel="icon" href="/favicon.ico" />
             </Head>
-            <div className='page-container w-full px-16 py-4 min-h-[70vh] bg-lt-mode-bg flex flex-col justify-center'>
+            <div className='page-container w-full px-6 laptop:px-16 py-4 min-h-[70vh] bg-lt-mode-bg flex flex-col justify-center'>
                 <h1 className='text-2xl'>🦄 Ooops ... 404! Page Not Found.</h1>
-                <p className='text-lt-mode-text leading-10'>Click here to return to <Link href='/'><a className='text-blue-600'>homepage</a></Link>.</p>
+                <p className='text-lt-mode-text leading-10'>Click here to return to <Link href='/'><a className='return-link'>homepage</a></Link>.</p>
             </div>
         </>
     );

--- a/pages/countries/[slug].tsx
+++ b/pages/countries/[slug].tsx
@@ -92,7 +92,7 @@ const Country = ({
             <Head>
                 <title>{country.name}</title>
             </Head>
-            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 laptop:px-16 py-6">
+            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 laptop:px-12 py-6">
                 <Link
                     href="/"
                     className="min-w-[120px] flex flex-row justify-center items-center gap-4 bg-white shadow-md rounded-md border"

--- a/pages/countries/[slug].tsx
+++ b/pages/countries/[slug].tsx
@@ -92,7 +92,7 @@ const Country = ({
             <Head>
                 <title>{country.name}</title>
             </Head>
-            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 tablet:px-16 py-6">
+            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 laptop:px-16 py-6">
                 <Link
                     href="/"
                     className="min-w-[120px] flex flex-row justify-center items-center gap-4 bg-white shadow-md rounded-md border"

--- a/pages/countries/[slug].tsx
+++ b/pages/countries/[slug].tsx
@@ -92,7 +92,7 @@ const Country = ({
             <Head>
                 <title>{country.name}</title>
             </Head>
-            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-16 py-6">
+            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 tablet:px-16 py-6">
                 <Link
                     href="/"
                     className="min-w-[120px] flex flex-row justify-center items-center gap-4 bg-white shadow-md rounded-md border"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -94,7 +94,7 @@ const Home = ({
             <Head>
                 <title>World of Countries</title>
             </Head>
-            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 tablet:px-16">
+            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 laptop:px-16">
                 {/* Toolbar */}
                 <div className="flex flex-col gap-8 tablet:flex-row tablet:gap-2 py-6 justify-between">
                     {/* Search Bar */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -94,9 +94,9 @@ const Home = ({
             <Head>
                 <title>World of Countries</title>
             </Head>
-            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-16">
+            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 tablet:px-16">
                 {/* Toolbar */}
-                <div className="flex flex-col gap-8 tablet:flex-row tablet:gap-2 py-4 justify-between">
+                <div className="flex flex-col gap-8 tablet:flex-row tablet:gap-2 py-6 justify-between">
                     {/* Search Bar */}
                     <SearchBar
                         value={query}
@@ -108,7 +108,7 @@ const Home = ({
                 </div>
 
                 {/* Country List */}
-                <div className="grid grid-cols-1 px-4 py-10 tablet:px-0 tablet:grid-cols-2 laptop:grid-cols-4 desktop:grid-cols-6 gap-8">
+                <div className="grid grid-cols-1 py-10 tablet:grid-cols-2 laptop:grid-cols-4 desktop:grid-cols-6 gap-8">
                     {searchResults.length > 0 ? (
                         searchResults.map((item, index) => (
                             <a key={index} href={`/countries/${item.name.toLowerCase().replace(/ /g, "_")}`}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -94,7 +94,7 @@ const Home = ({
             <Head>
                 <title>World of Countries</title>
             </Head>
-            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 laptop:px-16">
+            <div className="page-container min-h-screen bg-lt-mode-bg w-full px-6 laptop:px-12">
                 {/* Toolbar */}
                 <div className="flex flex-col gap-8 tablet:flex-row tablet:gap-2 py-6 justify-between">
                     {/* Search Bar */}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -48,3 +48,11 @@ body.dark .theme-toggler-text,
 body.dark a {
     @apply text-gray-100 hover:text-white
 }
+
+.return-link {
+    @apply text-blue-600;
+}
+
+body.dark .return-link {
+    @apply text-blue-400;
+}


### PR DESCRIPTION
### Description

Changes include:

- Set media query breakpoint for mobile & tablet size to have `px-6` instead of `px-16`
- Set media query breakpoint for laptop size to have `px-12` instead of `px-16`
- All component share consistent padding
   - Header
   - Footer
   - Main / Body
   - 404 page 

### Testing

Tested on multiple views

- [x] Mobile S8 (same size to S8)
- [x] Tablet iPad, iPad Mini, iPad Pro
- [x] Laptop / Desktop

All good ✅ 